### PR TITLE
use better key for checkboxes

### DIFF
--- a/index.js
+++ b/index.js
@@ -775,7 +775,7 @@ Object.defineProperty(Choices.prototype, 'checked', {
         return acc;
       }
       if (choice.checked === true) {
-        acc.push(choice.value);
+        acc.push(choice.name);
       }
       return acc;
     }.bind(this), []);


### PR DESCRIPTION
When choices is an object, we usually specify three fields:
short, name, value.
I feel like name is the thing you use under the hood and value is the display value.
Here we are trying to use the value as part of the underlying answer, it should be changed to name.